### PR TITLE
Media poro

### DIFF
--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -27,6 +27,18 @@ class Media
     @poster             = media_data[:poster]
   end
 
+  def subscription_services
+    # return ['Not Available For Streaming'] if streaming_services == []
+    # this was an idea but doesn't seem to be appropriate to be handled by poros 
+    # maybe should be done in view on FE
+    services = streaming_services.select do |service|
+      service[:type] == 'sub'
+    end
+    services.map do |service|
+      service[:name]
+    end
+  end
+
   # make a method to find the streaming services wher type is 'sub' 
   # or 'free' maybe? 
 end

--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -25,12 +25,15 @@ class Media
     @language           = media_data[:original_language]
     @streaming_services = media_data[:sources]
     @poster             = media_data[:poster]
+    @sub_services       = subscription_services
   end
 
   def subscription_services
     # return ['Not Available For Streaming'] if streaming_services == []
-    # this was an idea but doesn't seem to be appropriate to be handled by poros 
+
+    # ^^ this was an idea but doesn't seem to be appropriate to be handled by poros 
     # maybe should be done in view on FE
+
     services = streaming_services.select do |service|
       service[:type] == 'sub'
     end
@@ -38,7 +41,4 @@ class Media
       service[:name]
     end
   end
-
-  # make a method to find the streaming services wher type is 'sub' 
-  # or 'free' maybe? 
 end

--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -9,8 +9,8 @@ class Media
               :release_year,
               :runtime,
               :language,
-              :streaming_services,
-              :poster,
+              :sub_services,
+              :poster
 
   def initialize(media_data)
     @id                 = media_data[:id]
@@ -28,19 +28,11 @@ class Media
     @sub_services       = subscription_services
   end
 
-  # will want to add @sub_service to the serializer and remove @streaming_services
 
   def subscription_services
-    # return ['Not Available For Streaming'] if streaming_services == []
-
-    # ^^ this was an idea but doesn't seem to be appropriate to be handled by poros 
-    # maybe should be done in view on FE
-
-    services = streaming_services.select do |service|
+    services = @streaming_services.select do |service|
       service[:type] == 'sub'
     end
-    services.map do |service|
-      service[:name]
-    end
+    services.map { |service| service[:name] }
   end
 end

--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -10,7 +10,7 @@ class Media
               :runtime,
               :language,
               :streaming_services,
-              :poster
+              :poster,
 
   def initialize(media_data)
     @id                 = media_data[:id]
@@ -27,6 +27,8 @@ class Media
     @poster             = media_data[:poster]
     @sub_services       = subscription_services
   end
+
+  # will want to add @sub_service to the serializer and remove @streaming_services
 
   def subscription_services
     # return ['Not Available For Streaming'] if streaming_services == []

--- a/app/serializers/media_serializer.rb
+++ b/app/serializers/media_serializer.rb
@@ -10,6 +10,6 @@ class MediaSerializer
               :release_year,
               :runtime,
               :language,
-              :streaming_services,
+              :sub_services,
               :poster
 end

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe Media do
+  before(:each) do
+    @media_data = {:id=>3173903,
+      :title=>"Breaking Bad",
+      :original_title=>"Breaking Bad",
+      :plot_overview=>
+       "When Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+      :type=>"tv_series",
+      :runtime_minutes=>45,
+      :year=>2008,
+      :end_year=>2013,
+      :release_date=>"2008-01-20",
+      :imdb_id=>"tt0903747",
+      :tmdb_id=>1396,
+      :tmdb_type=>"tv",
+      :genres=>nil,
+      :genre_names=>['Drama', 'Dark Comedy'],
+      :user_rating=>9.3,
+      :critic_score=>85,
+      :us_rating=>"TV-MA",
+      :poster=>"https://cdn.watchmode.com/posters/03173903_poster_w185.jpg",
+      :backdrop=>"https://cdn.watchmode.com/backdrops/03173903_bd_w780.jpg",
+      :original_language=>"en",
+      :similar_titles=>[3131293],
+      :networks=>[8],
+      :network_names=>["AMC"],
+      :relevance_percentile=>98.8,
+      :trailer=>"https://www.youtube.com/watch?v=5NpEA2yaWVQ",
+      :trailer_thumbnail=>"https://cdn.watchmode.com/video_thumbnails/536028_pthumbnail_320.jpg",
+      :sources=>
+       [{:source_id=>349,
+         :name=>"iTunes",
+         :type=>"buy",
+         :region=>"US",
+         :ios_url=>"Deeplinks available for paid plans only.",
+         :android_url=>"Deeplinks available for paid plans only.",
+         :web_url=>"https://itunes.apple.com/us/tv-season/felina/id665386598?i=717897170&at=10laHb",
+         :format=>"SD",
+         :price=>1.99,
+         :seasons=>nil,
+         :episodes=>nil},
+        {:source_id=>349,
+         :name=>"iTunes",
+         :type=>"buy",
+         :region=>"US",
+         :ios_url=>"Deeplinks available for paid plans only.",
+         :android_url=>"Deeplinks available for paid plans only.",
+         :web_url=>"https://itunes.apple.com/us/tv-season/felina/id665386598?i=717897170&at=10laHb",
+         :format=>"HD",
+         :price=>2.99,
+         :seasons=>nil,
+         :episodes=>nil},
+        {:source_id=>203,
+         :name=>"Netflix",
+         :type=>"sub",
+         :region=>"US",
+         :ios_url=>"Deeplinks available for paid plans only.",
+         :android_url=>"Deeplinks available for paid plans only.",
+         :web_url=>"https://www.netflix.com/watch/70236428",
+         :format=>"4K",
+         :price=>nil,
+         :seasons=>nil,
+         :episodes=>nil}]}
+  end
+
+  it 'exists with attributes' do
+    media = Media.new(@media_data)
+
+    expect(media).to be_a Media
+    expect(media.id).to be_a Integer
+    expect(media.title).to be_a String
+    expect(media.audience_score).to be_a Float
+    expect(media.rating).to be_a String
+    expect(media.type).to be_a String
+    expect(media.description).to be_a String
+    expect(media.genres).to be_a Array
+    media.genres.each do |genre|
+      expect(genre).to be_a String
+    end
+    expect(media.release_year).to be_a Integer
+    expect(media.runtime).to be_a Integer
+    expect(media.language).to be_a String
+    expect(media.streaming_services).to be_a Array
+    expect(media.poster).to be_a String
+  end
+  
+  describe '#subscription_services' do
+    it 'returns the services media is available with a subscription' do
+      media0 = Media.new({:sources=>[]})
+      media1 = Media.new(@media_data)
+      media2 = Media.new(:sources=>
+        [{:source_id=>349,
+          :name=>"Prime",
+          :type=>"sub",
+          :region=>"US",
+          :ios_url=>"Deeplinks available for paid plans only.",
+          :android_url=>"Deeplinks available for paid plans only.",
+          :web_url=>"https://itunes.apple.com/us/tv-season/felina/id665386598?i=717897170&at=10laHb",
+          :format=>"SD",
+          :price=>nil,
+          :seasons=>nil,
+          :episodes=>nil},
+         {:source_id=>349,
+          :name=>"iTunes",
+          :type=>"buy",
+          :region=>"US",
+          :ios_url=>"Deeplinks available for paid plans only.",
+          :android_url=>"Deeplinks available for paid plans only.",
+          :web_url=>"https://itunes.apple.com/us/tv-season/felina/id665386598?i=717897170&at=10laHb",
+          :format=>"HD",
+          :price=>2.99,
+          :seasons=>nil,
+          :episodes=>nil},
+         {:source_id=>203,
+          :name=>"Netflix",
+          :type=>"sub",
+          :region=>"US",
+          :ios_url=>"Deeplinks available for paid plans only.",
+          :android_url=>"Deeplinks available for paid plans only.",
+          :web_url=>"https://www.netflix.com/watch/70236428",
+          :format=>"4K",
+          :price=>nil,
+          :seasons=>nil,
+          :episodes=>nil}])
+
+          expect(media0.subscription_services).to eq([])
+          expect(media1.subscription_services).to eq(['Netflix'])
+          expect(media2.subscription_services.sort).to eq(['Netflix', 'Prime'].sort)
+        end
+  end
+end

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Media do
       :title=>"Breaking Bad",
       :original_title=>"Breaking Bad",
       :plot_overview=>
-       "When Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He becomes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world of drugs and crime.",
+       "Guy things cancer is excuse to do crime.",
       :type=>"tv_series",
       :runtime_minutes=>45,
       :year=>2008,
@@ -69,21 +69,17 @@ RSpec.describe Media do
     media = Media.new(@media_data)
 
     expect(media).to be_a Media
-    expect(media.id).to be_a Integer
-    expect(media.title).to be_a String
-    expect(media.audience_score).to be_a Float
-    expect(media.rating).to be_a String
-    expect(media.type).to be_a String
-    expect(media.description).to be_a String
-    expect(media.genres).to be_a Array
-    media.genres.each do |genre|
-      expect(genre).to be_a String
-    end
-    expect(media.release_year).to be_a Integer
-    expect(media.runtime).to be_a Integer
-    expect(media.language).to be_a String
-    expect(media.streaming_services).to be_a Array
-    expect(media.poster).to be_a String
+    expect(media.title).to eq('Breaking Bad')
+    expect(media.audience_score).to eq(9.3)
+    expect(media.rating).to eq('TV-MA')
+    expect(media.type).to eq('tv_series')
+    expect(media.description).to eq('Guy things cancer is excuse to do crime.')
+    expect(media.genres).to eq(['Drama', 'Dark Comedy'])
+    expect(media.release_year).to eq(2008)
+    expect(media.runtime).to eq(45)
+    expect(media.language).to eq('en')
+    expect(media.sub_services).to eq(['Netflix'])
+    expect(media.poster).to eq('https://cdn.watchmode.com/posters/03173903_poster_w185.jpg')
   end
   
   describe '#subscription_services' do

--- a/spec/requests/api/v1/media_details/media_details_request_spec.rb
+++ b/spec/requests/api/v1/media_details/media_details_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Watchmode API' do 
   describe 'media details request' do 
     before(:each) do
-      stub_request(:get, "https://api.watchmode.com/v1/title/3173903/details?apiKey=oPOCz5GkaVYBzuHGKiWLGu3nrNkzeHYcFJ89dd8e")
+      stub_request(:get, "https://api.watchmode.com/v1/title/3173903/details?apiKey=#{ENV['watch_mode_api_key']}")
         .to_return(status: 200, body: File.read('spec/fixtures/breaking_bad_details_3173903.json'), headers: {})
     end
 
@@ -33,7 +33,7 @@ RSpec.describe 'Watchmode API' do
         :release_year,
         :runtime,
         :language,
-        :streaming_services,
+        :sub_services,
         :poster
       ].sort)
       expect(media_data[:data][:attributes][:id]).to be_an Integer
@@ -46,7 +46,10 @@ RSpec.describe 'Watchmode API' do
       expect(media_data[:data][:attributes][:release_year]).to be_an Integer
       expect(media_data[:data][:attributes][:runtime]).to be_an Integer
       expect(media_data[:data][:attributes][:language]).to be_a String
-      expect(media_data[:data][:attributes][:streaming_services]).to be_an Array
+      expect(media_data[:data][:attributes][:sub_services]).to be_an Array
+      media_data[:data][:attributes][:sub_services].each do |service|
+        expect(service).to be_a String
+      end
       expect(media_data[:data][:attributes][:poster]).to be_a String
     end
   end


### PR DESCRIPTION
This will not close an issue, it is part of the media details service issue

# Summary of things changed:
Added media poros with method to return only the subscription service(s). Updated Serializer and request specs to reflect this as well.


# List any known issues (include relevant code snippets): 
  - None

# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Json response snippet: 
```
{:data=>
  {:id=>"3173903",
   :type=>"media",
   :attributes=>
    {:id=>3173903,
     :title=>"Breaking Bad",
     :audience_score=>9.3,
     :rating=>"TV-MA",
     :type=>"tv_series",
     :description=>
      "When Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III cancer and given a prognosis of only two years left to live. He be
comes filled with a sense of fearlessness and an unrelenting desire to secure his family's financial future at any cost as he enters the dangerous world
 of drugs and crime.",
     :genres=>[],
     :release_year=>2008,
     :runtime=>45,
     :language=>"en",
     :sub_services=>["Netflix"],
     :poster=>"https://cdn.watchmode.com/posters/03173903_poster_w185.jpg"}}}
```

