### PR TITLE
User destroy

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -19,8 +19,12 @@ class Api::V1::UsersController < ApplicationController
   end
 
   def destroy
-    User.destroy(params[:id])
-    render status: :no_content
+    begin
+      User.destroy(params[:id])
+      render status: :no_content
+    rescue StandardError => e
+      render json: {message: "User with id #{params[:id]} not found"}, status: 404 
+    end
   end
 
   private

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,5 +1,5 @@
 class List < ApplicationRecord
   belongs_to :user
-  has_many :media_lists
+  has_many :media_lists, dependent: :destroy
   has_many :user_medias, through: :media_lists
 end

--- a/app/models/media_list.rb
+++ b/app/models/media_list.rb
@@ -1,7 +1,7 @@
 class MediaList < ApplicationRecord
   belongs_to :list
   belongs_to :user_media
-  #Might need to add optional: true next to :user_memdia in the future
+  #Might need to add optional: true next to :user_media in the future
   #so that media_list can be created without a user_media_id. 
   has_one :user, through: :list
 

--- a/app/models/media_list.rb
+++ b/app/models/media_list.rb
@@ -1,5 +1,15 @@
 class MediaList < ApplicationRecord
   belongs_to :list
   belongs_to :user_media
+  #Might need to add optional: true next to :user_memdia in the future
+  #so that media_list can be created without a user_media_id. 
   has_one :user, through: :list
+
+  after_destroy :destroy_user_media
+
+  private 
+
+  def destroy_user_media 
+    user_media.destroy
+  end
 end

--- a/app/services/trending_media_service.rb
+++ b/app/services/trending_media_service.rb
@@ -1,13 +1,13 @@
 class TrendingMediaService 
 
   def self.details
-    response = conn.get("/trending/all/day")
+    response = conn.get("/3/trending/all/day")
     JSON.parse(response.body, symbolize_names: true)
   end
 
   private 
 
   def self.conn 
-    Faraday.new(url: "https://api.themoviedb.org/3", params: { api_key: ENV['moviedb_api_key']})
+    Faraday.new(url: "https://api.themoviedb.org", params: { api_key: ENV['moviedb_api_key']})
   end
 end

--- a/spec/models/media_list_spec.rb
+++ b/spec/models/media_list_spec.rb
@@ -6,4 +6,30 @@ RSpec.describe MediaList do
     it { should belong_to :user_media }
     it { should have_one(:user).through(:list) }
   end
+
+  before(:each) do 
+    @user = create(:user)
+    @want_to_watch = @user.lists.create(name: "want to watch")
+    @currently_watching = @user.lists.create(name: "currently watching")
+    @watched = @user.lists.create(name: "watched")
+    @user_media1 = UserMedia.create(media_id: 1, user_rating: nil , user_review: "")
+    @user_media2 = UserMedia.create(media_id: 2, user_rating: nil, user_review: "")
+    @user_media3 = UserMedia.create(media_id: 3, user_rating: 1, user_review: "DNF")
+    @media_list1 = @want_to_watch.media_lists.create(user_media_id: @user_media1.id)
+    @media_list2 = @currently_watching.media_lists.create(user_media_id: @user_media2.id)
+    @media_list3 = @watched.media_lists.create(user_media_id: @user_media3.id)
+  end
+
+  describe 'instance methods' do 
+    describe 'destroy' do 
+      it 'destroys its associated user_media' do 
+        
+        expect(UserMedia.all).to eq([@user_media1, @user_media2, @user_media3])
+        
+        @media_list1.destroy
+
+        expect(UserMedia.all).to eq([@user_media2, @user_media3])
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/users/user_request_spec.rb
+++ b/spec/requests/api/v1/users/user_request_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe 'Users API' do
 
       expect(response).to_not be_successful
       expect(response.status).to eq(404)
+      expect(result[:message]).to eq("User with id 1 not found")
     end
   end
 end

--- a/spec/requests/api/v1/users/user_request_spec.rb
+++ b/spec/requests/api/v1/users/user_request_spec.rb
@@ -125,15 +125,26 @@ RSpec.describe 'Users API' do
   end
 
   describe 'deleting a user' do
-    it 'destroys the user' do
+    it 'destroys the user and all associated resources' do
       user = create(:user)
+      want_to_watch = user.lists.create(name: "want to watch")
+      currently_watching = user.lists.create(name: "currently watching")
+      watched = user.lists.create(name: "watched")
+      user_media1 = UserMedia.create(media_id: 1, user_rating: nil , user_review: "")
+      user_media2 = UserMedia.create(media_id: 2, user_rating: nil, user_review: "")
+      user_media3 = UserMedia.create(media_id: 3, user_rating: 1, user_review: "DNF")
+      media_list1 = want_to_watch.media_lists.create(user_media_id: user_media1.id)
+      media_list2 = currently_watching.media_lists.create(user_media_id: user_media2.id)
+      media_list3 = watched.media_lists.create(user_media_id: user_media3.id)
 
       delete "/api/v1/users/#{user.id}"
 
       expect(response).to be_successful
       expect(response.status).to eq(204)
-      expect(User.count).to eq(0)
-      expect(User.last).to eq(nil)
+      expect(User.all).to eq([])
+      expect(List.all).to eq([])
+      expect(UserMedia.all).to eq([])
+      expect(MediaList.all).to eq([])
     end
   end
 end

--- a/spec/requests/api/v1/users/user_request_spec.rb
+++ b/spec/requests/api/v1/users/user_request_spec.rb
@@ -146,5 +146,15 @@ RSpec.describe 'Users API' do
       expect(UserMedia.all).to eq([])
       expect(MediaList.all).to eq([])
     end
+
+    it 'returns an error when a user that does not exist is deleted' do 
+
+      delete "/api/v1/users/1"
+
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(404)
+    end
   end
 end


### PR DESCRIPTION
Issue #38 

# Summary of things changed:
- When a user is deleted from the database, all of the user's resources are also deleted, including resources from the `user_media` table. 
- The primary change occurred in the `media_list` model where an `after_destroy` callback was created. This callback ensures that once the `media_list` was destroyed (because of the dependent destroy in `user` and `list`), the associated `user_media` resource is also destroyed. 
- Added rescue block for the `users_controller` destroy action in the event that a user id that doesn't exist hits the endpoint. I have added a sad path test for this rescue block. 

# List any known issues (include relevant code snippets): 
- FYI In the `media_list` model,   we might need to add `optional: true` next to `belongs_to :user_media` in the future
  so that `media_list` can be created without a `user_media_id`. Not sure if this is necessary yet so I just left a commented out note.

# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Json response snippet: 

No JSON body for when a user is successfully deleted

Sad Path:
```
{:message=>"User with id # not found"}
```

