### PR TITLE
Media with user

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MediaController < ApplicationController
   def show
-    media = MediaFacade.details(params[:id])
+    media = MediaFacade.details(params[:id], params[:user_id])
     if media
       render json: MediaSerializer.new(media), status: :ok
     else

--- a/app/facade/media_facade.rb
+++ b/app/facade/media_facade.rb
@@ -1,7 +1,7 @@
 class MediaFacade
-  def self.details(id)
-    media_data = MediaService.details(id)
-    Media.new(media_data) if media_data[:id]
+  def self.details(id, user_id = nil)
+      media_data = MediaService.details(id)
+      Media.new(media_data, user_id) if media_data[:id]
   end
 
   def self.user_list_details(user_id, list_name)

--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -14,9 +14,10 @@ class Media
               :imdb_id,
               :tmdb_id,
               :tmdb_type,
-              :trailer
+              :trailer,
+              :user_lists
 
-  def initialize(media_data)
+  def initialize(media_data, user_id = nil)
     @id                 = media_data[:id]
     @title              = media_data[:title] || media_data[:name]
     @audience_score     = media_data[:user_rating]
@@ -33,6 +34,7 @@ class Media
     @tmdb_id            = media_data[:tmdb_id]
     @tmdb_type          = media_data[:tmdb_type]
     @trailer            = media_data[:trailer]
+    @user_lists         = lists(user_id)
     @sub_services       = subscription_services
   end
 
@@ -43,5 +45,16 @@ class Media
       service[:type] == 'sub'
     end
     services.map { |service| service[:name] }
+  end
+
+  private
+
+  def lists(user_id)
+    user = User.find_by(id: user_id)
+    if user
+      user.user_medias.take.try(:list).name || 'None'
+    else
+      'None'
+    end
   end
 end

--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -52,7 +52,7 @@ class Media
   def lists(user_id)
     user = User.find_by(id: user_id)
     if user
-      user.user_medias.take.try(:list).name || 'None'
+      user.user_medias.where(media_id: self.id).take.try(:list).name || 'None'
     else
       'None'
     end

--- a/app/serializers/media_serializer.rb
+++ b/app/serializers/media_serializer.rb
@@ -15,5 +15,6 @@ class MediaSerializer
               :imdb_id,
               :tmdb_id,
               :tmdb_type,
-              :trailer
+              :trailer,
+              :user_lists
 end

--- a/spec/facades/media_facade_spec.rb
+++ b/spec/facades/media_facade_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe MediaFacade, :vcr do
 
       expect(media_details).to be_a Media
       expect(media_details.id).to eq(@breaking_bad_id)
+      expect(media_details.user_lists).to eq('None')
+    end
+
+    it 'can optionally include data about a users lists' do
+      user = create(:user) 
+      list = user.lists.last
+      user_media = create(:user_media, media_id: 3173903) 
+      MediaList.create(list: list, user_media: user_media) 
+      media_details = MediaFacade.details(@breaking_bad_id, user.id)
+
+      expect(media_details).to be_a Media
+      expect(media_details.id).to eq(@breaking_bad_id)
+      expect(media_details.user_lists).to eq('Watched')
     end
   end
 

--- a/spec/fixtures/vcr_cassettes/MediaFacade/_details/can_optionally_include_data_about_a_users_lists.yml
+++ b/spec/fixtures/vcr_cassettes/MediaFacade/_details/can_optionally_include_data_about_a_users_lists.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.watchmode.com/v1/title/3173903/details?apiKey=<watch_mode_api_key>&append_to_response=sources
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 01 Mar 2023 16:39:16 GMT
+      Server:
+      - Apache/2.4.54 (Ubuntu)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      X-Ratelimit-Limit:
+      - '120'
+      X-Ratelimit-Remaining:
+      - '120'
+      Retry-After:
+      - '44'
+      X-Account-Quota:
+      - '1000'
+      X-Account-Quota-Used:
+      - '53'
+      Vary:
+      - Accept-Encoding
+      Upgrade:
+      - h2,h2c
+      Connection:
+      - Upgrade
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":3173903,"title":"Breaking Bad","original_title":"Breaking Bad","plot_overview":"When
+        Walter White, a New Mexico chemistry teacher, is diagnosed with Stage III
+        cancer and given a prognosis of only two years left to live. He becomes filled
+        with a sense of fearlessness and an unrelenting desire to secure his family''s
+        financial future at any cost as he enters the dangerous world of drugs and
+        crime.","type":"tv_series","runtime_minutes":45,"year":2008,"end_year":2013,"release_date":"2008-01-20","imdb_id":"tt0903747","tmdb_id":1396,"tmdb_type":"tv","genres":null,"genre_names":[],"user_rating":9.3,"critic_score":85,"us_rating":"TV-MA","poster":"https:\/\/cdn.watchmode.com\/posters\/03173903_poster_w185.jpg","backdrop":"https:\/\/cdn.watchmode.com\/backdrops\/03173903_bd_w780.jpg","original_language":"en","similar_titles":[3131293,383653,3186135,3129354,313542,3124749,340865,3109684,350372],"networks":[8],"network_names":["AMC"],"relevance_percentile":98.8,"trailer":"https:\/\/www.youtube.com\/watch?v=5NpEA2yaWVQ","trailer_thumbnail":"https:\/\/cdn.watchmode.com\/video_thumbnails\/536028_pthumbnail_320.jpg","sources":[{"source_id":349,"name":"iTunes","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/itunes.apple.com\/us\/tv-season\/felina\/id665386598?i=717897170&at=10laHb","format":"SD","price":1.99,"seasons":null,"episodes":null},{"source_id":349,"name":"iTunes","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/itunes.apple.com\/us\/tv-season\/felina\/id665386598?i=717897170&at=10laHb","format":"HD","price":2.99,"seasons":null,"episodes":null},{"source_id":140,"name":"Google
+        Play","type":"buy","region":"US","ios_url":"Deeplinks available for paid plans
+        only.","android_url":"Deeplinks available for paid plans only.","web_url":"https:\/\/play.google.com\/store\/tv\/show?id=L2wfgMDGiBk&cdid=tvseason-QloudPiQicc&gdid=tvepisode-9VYSQkZP4Gc&PAffiliateID=1101l32vn","format":"HD","price":2.99,"seasons":null,"episodes":null},{"source_id":140,"name":"Google
+        Play","type":"buy","region":"US","ios_url":"Deeplinks available for paid plans
+        only.","android_url":"Deeplinks available for paid plans only.","web_url":"https:\/\/play.google.com\/store\/tv\/show?id=L2wfgMDGiBk&cdid=tvseason-QloudPiQicc&gdid=tvepisode-9VYSQkZP4Gc&PAffiliateID=1101l32vn","format":"SD","price":1.99,"seasons":null,"episodes":null},{"source_id":307,"name":"VUDU","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.vudu.com\/content\/movies\/details\/content\/460653","format":"HD","price":2.99,"seasons":null,"episodes":null},{"source_id":307,"name":"VUDU","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.vudu.com\/content\/movies\/details\/content\/460653","format":"SD","price":1.99,"seasons":null,"episodes":null},{"source_id":344,"name":"YouTube","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.youtube.com\/watch?v=9VYSQkZP4Gc","format":"HD","price":2.99,"seasons":null,"episodes":null},{"source_id":344,"name":"YouTube","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.youtube.com\/watch?v=9VYSQkZP4Gc","format":"SD","price":1.99,"seasons":null,"episodes":null},{"source_id":24,"name":"Amazon","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.amazon.com\/gp\/video\/detail\/amzn1.dv.gti.9aa9f77a-dc91-b172-9a35-b9a6f34728b8?tag=","format":"SD","price":1.99,"seasons":null,"episodes":null},{"source_id":24,"name":"Amazon","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.amazon.com\/gp\/video\/detail\/amzn1.dv.gti.9aa9f77a-dc91-b172-9a35-b9a6f34728b8?tag=","format":"4K","price":3.99,"seasons":null,"episodes":null},{"source_id":24,"name":"Amazon","type":"buy","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.amazon.com\/gp\/video\/detail\/amzn1.dv.gti.9aa9f77a-dc91-b172-9a35-b9a6f34728b8?tag=","format":"HD","price":2.99,"seasons":null,"episodes":null},{"source_id":398,"name":"Microsoft
+        Store","type":"buy","region":"US","ios_url":"Deeplinks available for paid
+        plans only.","android_url":"Deeplinks available for paid plans only.","web_url":"https:\/\/www.microsoft.com\/en-us\/p\/season-5\/8d6kgwzlcwj3","format":"SD","price":1.99,"seasons":null,"episodes":null},{"source_id":398,"name":"Microsoft
+        Store","type":"buy","region":"US","ios_url":"Deeplinks available for paid
+        plans only.","android_url":"Deeplinks available for paid plans only.","web_url":"https:\/\/www.microsoft.com\/en-us\/p\/season-5\/8d6kgwzlcwj3","format":"HD","price":2.99,"seasons":null,"episodes":null},{"source_id":203,"name":"Netflix","type":"sub","region":"US","ios_url":"Deeplinks
+        available for paid plans only.","android_url":"Deeplinks available for paid
+        plans only.","web_url":"https:\/\/www.netflix.com\/watch\/70236428","format":"4K","price":null,"seasons":null,"episodes":null}]}'
+  recorded_at: Wed, 01 Mar 2023 16:39:16 GMT
+recorded_with: VCR 6.1.0

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -127,6 +127,19 @@ RSpec.describe Media do
 
     expect(media.user_lists).to eq "Want to Watch"
   end
+  
+  it 'only returns list information for this piece of media' do
+    user = create(:user) 
+    list = user.lists.first
+    other_list = user.lists.last
+    user_media = create(:user_media, media_id: 3173903) 
+    user_media2 = create(:user_media) 
+    MediaList.create(list: list, user_media: user_media) 
+    MediaList.create(list: other_list, user_media: user_media2) 
+    media = Media.new(@heavy_media_data, user.id)
+
+    expect(media.user_lists).to eq "Want to Watch"
+  end
 
   describe '#subscription_services' do
     it 'returns the services media is available with a subscription' do

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -118,6 +118,16 @@ RSpec.describe Media do
     expect(media.trailer).to be nil
   end
 
+  it 'can be created with user list information' do
+    user = create(:user) 
+    list = user.lists.first
+    user_media = create(:user_media, media_id: 3173903) 
+    MediaList.create(list: list, user_media: user_media) 
+    media = Media.new(@heavy_media_data, user.id)
+
+    expect(media.user_lists).to eq "Want to Watch"
+  end
+
   describe '#subscription_services' do
     it 'returns the services media is available with a subscription' do
       media0 = Media.new({ :sources => [] })

--- a/spec/requests/api/v1/media/media_request_spec.rb
+++ b/spec/requests/api/v1/media/media_request_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe 'Watchmode API', :vcr do
       expect(media_data[:data][:attributes][:imdb_id]).to be_a String
       expect(media_data[:data][:attributes][:tmdb_id]).to be_a Integer
       expect(media_data[:data][:attributes][:tmdb_type]).to be_a String
+      expect(media_data[:data][:attributes][:user_lists]).to be_a String
     end
 
     it 'returns an error message when an incorrect id is passed' do

--- a/spec/requests/api/v1/media/media_request_spec.rb
+++ b/spec/requests/api/v1/media/media_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Watchmode API', :vcr do
   describe 'get media/id' do
     it 'sends media details' do
       expected_keys = %i[id title audience_score rating media_type description genres release_year
-                         runtime language sub_services poster trailer imdb_id tmdb_id tmdb_type]
+                         runtime language sub_services poster trailer imdb_id tmdb_id tmdb_type user_lists]
 
       show_id = 3_173_903
       get "/api/v1/media/#{show_id}"


### PR DESCRIPTION
Issue # None
# Summary of things changed:
Adjusts media details endpoint to optionally accept a user id. 
Media PORO now has a field that stores list data for a given user. 
List Data is a String.

# List any known issues (include relevant code snippets): 
  - None
# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Json response snippet: 
See Media details--adds field "user_lists": "Watched"


