### PR TITLE
46 delete user media from list

### DIFF
--- a/app/controllers/api/v1/users/media_controller.rb
+++ b/app/controllers/api/v1/users/media_controller.rb
@@ -14,6 +14,16 @@ class Api::V1::Users::MediaController < ApplicationController
       render status: :no_content
     end
   end
+
+  def destroy
+    user = User.find(params[:user_id])
+    user_media = user.user_medias.find_by(media_id: params[:id])
+    if user_media
+      user_media.destroy
+    else
+      raise ActiveRecord::RecordNotFound.new "Couldn't find UserMedia with the id: '#{params[:id]}'"
+    end
+  end
 end
 
 

--- a/app/models/user_media.rb
+++ b/app/models/user_media.rb
@@ -1,5 +1,5 @@
 class UserMedia < ApplicationRecord
-  has_one :media_list
+  has_one :media_list, dependent: :destroy
   has_one :list, through: :media_list
   has_one :user, through: :list
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, except: :index do
-        resources :media, only: [:create, :update], controller: 'users/media'
+        resources :media, only: [:create, :update, :destroy], controller: 'users/media'
         resources :lists, only: :index, controller: 'users/lists'
       end
       resources :media, only: [:show, :index]

--- a/spec/requests/api/v1/usermedia/usermedia_request_spec.rb
+++ b/spec/requests/api/v1/usermedia/usermedia_request_spec.rb
@@ -30,4 +30,23 @@ RSpec.describe 'Edit Media List API' do
       expect(user.user_medias.last.list.name).to eq "Want to Watch"
     end
   end
+  describe 'delete user_media/id' do
+    it 'deletes user_media for a user' do
+      user = create(:user) 
+      list_name = 'currently watching'
+      list = user.lists.find_by("name ILIKE ?", list_name)
+      user_media = create(:user_media, media_id: 3173903) 
+      media_list = MediaList.create(list: list, user_media: user_media)
+
+      expect(user.currently_watching).to eq([user_media])
+      expect(MediaList.find_by(list: list)).to eq(media_list)
+
+      delete "/api/v1/users/#{user.id}/media/#{user_media.media_id}"
+      
+      expect(response).to be_successful
+      expect(response.status).to eq 204
+      
+      expect(MediaList.find_by(list: list)).to be nil
+      expect(user.currently_watching).to eq([])
+    end
 end

--- a/spec/requests/api/v1/usermedia/usermedia_request_spec.rb
+++ b/spec/requests/api/v1/usermedia/usermedia_request_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Edit Media List API' do
+RSpec.describe 'Users Media List API' do
   describe 'patch user_media/id' do
     it 'changes or creates a media_list entry to link a usermedia to a list' do
       user = create(:user) 
@@ -30,6 +30,7 @@ RSpec.describe 'Edit Media List API' do
       expect(user.user_medias.last.list.name).to eq "Want to Watch"
     end
   end
+
   describe 'delete user_media/id' do
     it 'deletes user_media for a user' do
       user = create(:user) 
@@ -49,4 +50,61 @@ RSpec.describe 'Edit Media List API' do
       expect(MediaList.find_by(list: list)).to be nil
       expect(user.currently_watching).to eq([])
     end
+
+    it 'only deletes the user media off the list of a single user' do
+      list_name = 'currently watching'
+      breaking_bad_id = 3173903
+
+      user1 = create(:user) 
+      user1_list = user1.lists.find_by("name ILIKE ?", list_name)
+      user1_media = create(:user_media, media_id: breaking_bad_id) 
+      media_list1 = MediaList.create(list: user1_list, user_media: user1_media)
+
+      user2 = create(:user) 
+      user2_list = user2.lists.find_by("name ILIKE ?", list_name)
+      user2_media = create(:user_media, media_id: breaking_bad_id) 
+      media_list2 = MediaList.create(list: user2_list, user_media: user2_media)
+
+      expect(user1.currently_watching).to eq([user1_media])
+      expect(user2.currently_watching).to eq([user2_media])
+      expect(user1_media.media_id).to eq(user2_media.media_id)
+
+      delete "/api/v1/users/#{user1.id}/media/#{breaking_bad_id}"
+
+      expect(user1.currently_watching).to eq([])
+      expect(user2.currently_watching).to eq([user2_media])
+    end
+
+    it 'returns an error if the user cannot be found' do
+      list_name = 'currently watching'
+      breaking_bad_id = 3173903
+      
+      user1 = create(:user) 
+      user1_list = user1.lists.find_by("name ILIKE ?", list_name)
+      user1_media = create(:user_media, media_id: breaking_bad_id) 
+      media_list1 = MediaList.create(list: user1_list, user_media: user1_media)
+      not_real_user_id = User.last.id+1
+
+      delete "/api/v1/users/#{not_real_user_id}/media/#{breaking_bad_id}"
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq 404
+      error_json = JSON.parse(response.body, symbolize_names:true)
+      expect(error_json[:errors].first[:detail]).to eq("Couldn't find User with 'id'=#{not_real_user_id}")
+    end
+
+    it 'returns an error if trying to delete media a user doesnt have' do
+      breaking_bad_id = 3173903
+      
+      user1 = create(:user) 
+
+      expect(user1.user_medias).to be_empty
+
+      delete "/api/v1/users/#{user1.id}/media/#{breaking_bad_id}"
+      expect(response).to_not be_successful
+      expect(response.status).to eq 404
+      error_json = JSON.parse(response.body, symbolize_names:true)
+      expect(error_json[:errors].first[:detail]).to eq("Couldn't find UserMedia with the id: '3173903'")
+    end
+  end
 end


### PR DESCRIPTION
Issue resolve #46 

# Summary of things changed:

- add route for delete user media from list
- add happy path test for deleting a single user's media from their list
- add happy path test for checking a different user's media of the same id is not deleted
- error handling sad path test for user not existing given id
- error handling sad path test for user not owning user_media given media_id
- user/media controller destroy action added


# List any known issues (include relevant code snippets): 
  - none (crosses fingers) obvious sad paths covered
  - This functionality really relies on media only being allowed to live on a single user's list at a time


# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Json response snippet: 
given that user with id:1 exists and that breaking bad watchmode id is 3173903
### happy endpoint:
`DELETE "/api/v1/users/1/media/3173903"`
```
:no_content
```
### sad paths

`DELETE "/api/v1/users/<not a real user id>/media/3173903"`
```
{
    "message": "Record not Found",
    "errors": [
        {
            "detail": "Couldn't find User with 'id'=not a real user id",
            "status": "not_found"
        }
    ]
}
```
`DELETE "/api/v1/users/1/media/<not a watchmode media id>"`

```
{
    "message": "Record not Found",
    "errors": [
        {
            "detail": "Couldn't find UserMedia with the id: 'not a watchmode media id'",
            "status": "not_found"
        }
    ]
}
```
