### PR TITLE
Media updated at

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::MediaController < ApplicationController
 
   def index
     if params[:q].present?
-      results = MediaFacade.search(params[:q])
+      results = MediaFacade.search(params[:q], params[:user_id])
     else
       results = []
     end

--- a/app/facade/media_facade.rb
+++ b/app/facade/media_facade.rb
@@ -12,10 +12,10 @@ class MediaFacade
     end
   end
 
-  def self.search(query)
+  def self.search(query, user_id = nil)
     search_results = MediaService.search(query)
     search_results[:results].map do |media_data|
-      Media.new(media_data)
+      Media.new(media_data, user_id)
     end
   end
 end

--- a/app/facade/media_facade.rb
+++ b/app/facade/media_facade.rb
@@ -8,7 +8,7 @@ class MediaFacade
     user = User.find(user_id)
     list_media_ids = user.media_ids_for(list_name)
     list_media_ids.map do |media_id|
-      details(media_id)
+      details(media_id, user_id)
     end
   end
 

--- a/app/poros/media.rb
+++ b/app/poros/media.rb
@@ -16,7 +16,8 @@ class Media
               :tmdb_type,
               :trailer,
               :user_lists,
-              :user_rating
+              :user_rating,
+              :added_to_list_on
 
   def initialize(media_data, user_id = nil)
     @id                 = media_data[:id]
@@ -36,6 +37,7 @@ class Media
     @tmdb_type          = media_data[:tmdb_type]
     @trailer            = media_data[:trailer]
     @user_lists         = lists(user_id)
+    @added_to_list_on    = media_list_updated_at(user_id)
     @user_rating        = set_rating(user_id)
     @sub_services       = subscription_services
   end
@@ -64,6 +66,13 @@ class Media
     user = User.find_by(id: user_id)
     if user
       user.user_medias.where(media_id: self.id).take.try(:user_rating)
+    end
+  end
+
+  def media_list_updated_at(user_id)
+    user = User.find_by(id: user_id)
+    if user
+      user.user_medias.where(media_id: self.id).take.try(:media_list).try(:updated_at)
     end
   end
 end

--- a/app/serializers/media_serializer.rb
+++ b/app/serializers/media_serializer.rb
@@ -17,5 +17,6 @@ class MediaSerializer
               :tmdb_type,
               :trailer,
               :user_lists,
+              :added_to_list_on,
               :user_rating
 end

--- a/app/serializers/search_result_serializer.rb
+++ b/app/serializers/search_result_serializer.rb
@@ -1,4 +1,4 @@
 class SearchResultSerializer
   include JSONAPI::Serializer
-  attributes :id, :title, :media_type, :release_year, :tmdb_id, :tmdb_type, :poster
+  attributes :id, :title, :media_type, :release_year, :tmdb_id, :tmdb_type, :poster, :user_lists, :added_to_list_on, :user_rating
 end

--- a/spec/fixtures/vcr_cassettes/Watchmode_API/get_media_q_query_user_id_/returns_an_array_of_media_with_media_list_info_and_user_rating_given_a_user_id.yml
+++ b/spec/fixtures/vcr_cassettes/Watchmode_API/get_media_q_query_user_id_/returns_an_array_of_media_with_media_list_info_and_user_rating_given_a_user_id.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.watchmode.com/v1/autocomplete-search/?apiKey=<watch_mode_api_key>&search_field=name&search_type=2&search_value=everything
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Mar 2023 21:20:52 GMT
+      Server:
+      - Apache/2.4.54 (Ubuntu)
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+      X-Ratelimit-Limit:
+      - '120'
+      X-Ratelimit-Remaining:
+      - '120'
+      Retry-After:
+      - '8'
+      X-Account-Quota:
+      - '1000'
+      X-Account-Quota-Used:
+      - '95'
+      Vary:
+      - Accept-Encoding
+      Upgrade:
+      - h2,h2c
+      Connection:
+      - Upgrade
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"results":[{"name":"Everything Everywhere All at Once","relevance":250,"type":"movie","id":1516721,"year":2022,"result_type":"title","tmdb_id":545611,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01516721_poster_w185.jpg"},{"name":"Everything,
+        Everything","relevance":169.39,"type":"movie","id":1126597,"year":2017,"result_type":"title","tmdb_id":417678,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126597_poster_w185.jpg"},{"name":"To
+        Wong Foo, Thanks for Everything! Julie Newmar","relevance":167.82,"type":"movie","id":1435331,"year":1995,"result_type":"title","tmdb_id":9090,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01435331_poster_w185.jpg"},{"name":"Everything
+        You Always Wanted to Know About Sex *But Were Afraid to Ask","relevance":167.72,"type":"movie","id":1126554,"year":1972,"result_type":"title","tmdb_id":11624,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126554_poster_w185.jpg"},{"name":"Hello,
+        Goodbye, and Everything in Between","relevance":163.85,"type":"movie","id":1686838,"year":2022,"result_type":"title","tmdb_id":745376,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01686838_poster_w185.jpg"},{"name":"Everything
+        Is Illuminated","relevance":129.61,"type":"movie","id":1126513,"year":2005,"result_type":"title","tmdb_id":340,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126513_poster_w185.jpg"},{"name":"Everything
+        Sucks!","relevance":129.34,"type":"tv_series","id":339204,"year":2018,"result_type":"title","tmdb_id":76438,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/0339204_poster_w185.jpg"},{"name":"Everything
+        Must Go","relevance":128.34,"type":"movie","id":1126531,"year":2011,"result_type":"title","tmdb_id":45658,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126531_poster_w185.jpg"},{"name":"Everybody\u2019s
+        Everything","relevance":127.99,"type":"movie","id":1561344,"year":2019,"result_type":"title","tmdb_id":576712,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01561344_poster_w185.jpg"},{"name":"Everything''s
+        Gonna Be Great","relevance":127.91,"type":"movie","id":1126584,"year":1998,"result_type":"title","tmdb_id":81549,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126584_poster_w185.jpg"},{"name":"Everything
+        or Nothing","relevance":125.94,"type":"movie","id":1126574,"year":2012,"result_type":"title","tmdb_id":135921,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126574_poster_w185.jpg"},{"name":"Everything
+        Went Fine","relevance":124.16,"type":"movie","id":1628413,"year":2021,"result_type":"title","tmdb_id":735726,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01628413_poster_w185.jpg"},{"name":"Everything
+        You Want","relevance":123.79,"type":"movie","id":1443138,"year":2017,"result_type":"title","tmdb_id":457601,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01443138_poster_w185.jpg"},{"name":"Z:
+        The Beginning of Everything","relevance":123.4,"type":"tv_series","id":3147187,"year":2015,"result_type":"title","tmdb_id":64506,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03147187_poster_w185.jpg"},{"name":"Everything
+        Happens to Me","relevance":123.14,"type":"movie","id":174490,"year":1980,"result_type":"title","tmdb_id":11039,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/0174490_poster_w185.jpg"},{"name":"Diablo:
+        The Utimate Race","relevance":122.89,"type":"movie","id":1529806,"year":2019,"result_type":"title","tmdb_id":568637,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01529806_poster_w185.jpg"},{"name":"Everything
+        Calls for Salvation","relevance":120.87,"type":"tv_series","id":3187566,"year":2022,"result_type":"title","tmdb_id":134057,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03187566_poster_w185.jpg"},{"name":"Everything''s
+        Gone Wrong!","relevance":119.55,"type":"movie","id":1435806,"year":2018,"result_type":"title","tmdb_id":509421,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01435806_poster_w185.jpg"},{"name":"Everything
+        About Mustafa","relevance":96.97,"type":"movie","id":1126473,"year":2004,"result_type":"title","tmdb_id":56655,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126473_poster_w185.jpg"},{"name":"Everything
+        Will Be Ok","relevance":96.69,"type":"short_film","id":2166686,"year":2006,"result_type":"title","tmdb_id":32532,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/02166686_poster_w185.jpg"},{"name":"Everything
+        Is Copy","relevance":95.51,"type":"movie","id":1126510,"year":2015,"result_type":"title","tmdb_id":356325,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01126510_poster_w185.jpg"},{"name":"Everything
+        Is Love","relevance":95.22,"type":"movie","id":1163508,"year":2016,"result_type":"title","tmdb_id":442392,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01163508_poster_w185.jpg"},{"name":"A
+        Birder''s Guide to Everything","relevance":95.06,"type":"movie","id":15572,"year":2013,"result_type":"title","tmdb_id":174326,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/015572_poster_w185.jpg"},{"name":"Everything''s
+        Rosie","relevance":94.07,"type":"tv_series","id":3168965,"year":2010,"result_type":"title","tmdb_id":73573,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03168965_poster_w185.jpg"},{"name":"Little
+        Richard: I Am Everything","relevance":93.74,"type":"movie","id":1698835,"year":2023,"result_type":"title","tmdb_id":1053718,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01698835_poster_w185.jpg"},{"name":"Everything''s
+        Gonna Be Okay","relevance":93.31,"type":"tv_series","id":4145512,"year":2020,"result_type":"title","tmdb_id":91980,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/04145512_poster_w185.jpg"},{"name":"Everything
+        Everything Nothing Nothing","relevance":92.77,"type":"movie","id":1443142,"year":2012,"result_type":"title","tmdb_id":161545,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01443142_poster_w185.jpg"},{"name":"Everything
+        I Know About Love","relevance":91.47,"type":"tv_series","id":3185626,"year":2022,"result_type":"title","tmdb_id":202432,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03185626_poster_w185.jpg"},{"name":"Everything
+        and Nothing","relevance":82.31,"type":"tv_miniseries","id":339210,"year":2011,"result_type":"title","tmdb_id":67473,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/0339210_poster_w185.jpg"},{"name":"Everything
+        Is Samuel L. Jackson''s Fault","relevance":82.07,"type":"movie","id":2166630,"year":2013,"result_type":"title","tmdb_id":376980,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/02166630_poster_w185.jpg"},{"name":"Everything''s
+        Fine: A Panic Attack in D Major","relevance":82.07,"type":"short_film","id":2752294,"year":2018,"result_type":"title","tmdb_id":1057766,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/02752294_poster_w185.jpg"},{"name":"Everything
+        About the Actual Difference","relevance":81.22,"type":"short_film","id":2715253,"year":2022,"result_type":"title","tmdb_id":794913,"tmdb_type":"movie","image_url":null},{"name":"Everything
+        Wrong and Nowhere to Go","relevance":81.22,"type":"short_film","id":2746798,"year":2022,"result_type":"title","tmdb_id":1018271,"tmdb_type":"movie","image_url":null},{"name":"Everything
+        Else","relevance":81.19,"type":"tv_series","id":3179675,"year":2021,"result_type":"title","tmdb_id":114819,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03179675_poster_w185.jpg"},{"name":"Everything
+        Will Be Fine","relevance":81.19,"type":"tv_series","id":3176620,"year":2021,"result_type":"title","tmdb_id":129675,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03176620_poster_w185.jpg"},{"name":"The
+        Beginning and End of Everything","relevance":77.59,"type":"short_film","id":2739921,"year":2022,"result_type":"title","tmdb_id":979423,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/02739921_poster_w185.jpg"},{"name":"Alles
+        \u00fcber Martin Suter. Ausser die Wahrheit.","relevance":77.59,"type":"movie","id":1687443,"year":2022,"result_type":"title","tmdb_id":997668,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/01687443_poster_w185.jpg"},{"name":"Everything''s
+        Gonna Be All White","relevance":75.34,"type":"tv_miniseries","id":3182048,"year":2022,"result_type":"title","tmdb_id":157312,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03182048_poster_w185.jpg"},{"name":"Everything''s
+        Better than a Hooker","relevance":71.78,"type":"tv_movie","id":436799,"year":2018,"result_type":"title","tmdb_id":503649,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/0436799_poster_w185.jpg"},{"name":"Everything
+        Wrong with...","relevance":71.56,"type":"tv_series","id":3192790,"year":2012,"result_type":"title","tmdb_id":106776,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03192790_poster_w185.jpg"},{"name":"Everything''s
+        Trash","relevance":66.84,"type":"tv_series","id":3185081,"year":2022,"result_type":"title","tmdb_id":135312,"tmdb_type":"tv","image_url":"https:\/\/cdn.watchmode.com\/posters\/03185081_poster_w185.jpg"},{"name":"Everything
+        Is Connected: George Eliot''s Life","relevance":66.28,"type":"tv_movie","id":4157831,"year":2019,"result_type":"title","tmdb_id":648674,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/04157831_poster_w185.jpg"},{"name":"Everything
+        Not Saved","relevance":66.28,"type":"tv_movie","id":4157929,"year":2018,"result_type":"title","tmdb_id":980458,"tmdb_type":"movie","image_url":null},{"name":"Everything
+        She Ever Wanted","relevance":45,"type":"tv_miniseries","id":56126,"year":2009,"result_type":"title","tmdb_id":299709,"tmdb_type":"movie","image_url":"https:\/\/cdn.watchmode.com\/posters\/056126_poster_w185.jpg"},{"name":"Smile:
+        Forget Everything You Knew... A Debut Concert in London","relevance":32.4,"type":"tv_special","id":545026,"year":2022,"result_type":"title","tmdb_id":987764,"tmdb_type":"movie","image_url":null}]}'
+  recorded_at: Thu, 02 Mar 2023 21:20:52 GMT
+recorded_with: VCR 6.1.0

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Media do
     updated_at = media_list.updated_at
     media = Media.new(@heavy_media_data, user.id)
 
-    expect(media.list_updated_at).to eq updated_at
+    expect(media.added_to_list_on).to eq updated_at
   end
 
   it 'can be created with user rating information' do

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -141,6 +141,17 @@ RSpec.describe Media do
     expect(media.user_lists).to eq "Want to Watch"
   end
 
+  it 'has the time it was last put on a list' do
+    user = create(:user) 
+    list = user.lists.first
+    user_media = create(:user_media, media_id: 3173903) 
+    media_list = MediaList.create(list: list, user_media: user_media) 
+    updated_at = media_list.updated_at
+    media = Media.new(@heavy_media_data, user.id)
+
+    expect(media.list_updated_at).to eq updated_at
+  end
+
   it 'can be created with user rating information' do
     user = create(:user) 
     list = user.lists.first

--- a/spec/poros/media_spec.rb
+++ b/spec/poros/media_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Media do
     updated_at = media_list.updated_at
     media = Media.new(@heavy_media_data, user.id)
 
-    expect(media.added_to_list_on).to eq updated_at
+    expect(media.added_to_list_on).to be_within(1.second).of updated_at
   end
 
   it 'can be created with user rating information' do

--- a/spec/requests/api/v1/users/lists/user_list_request_spec.rb
+++ b/spec/requests/api/v1/users/lists/user_list_request_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe 'User Lists API' do
                                         :imdb_id,
                                         :tmdb_id,
                                         :tmdb_type,
-                                        :trailer
+                                        :trailer, 
+                                        :user_lists,
+                                        :added_to_list_on,
+                                        :user_rating
                                       )
         expect(attributes[:id]).to be_a(Integer)
         expect(attributes[:title]).to be_a(String)
@@ -73,6 +76,9 @@ RSpec.describe 'User Lists API' do
         expect(attributes[:tmdb_id]).to be_a(Integer)
         expect(attributes[:tmdb_type]).to be_a(String)
         expect(attributes[:trailer]).to be_a(String)
+        expect(attributes[:user_lists]).to be_a(String)
+        expect(attributes[:added_to_list_on]).to be_a(String)
+        expect(attributes[:user_rating]).to be_a(Integer)
       end
     end
 


### PR DESCRIPTION
Issue resolve #59 

# Summary of things changed:
Endpoint for user dashboard lists now sends response with user_lists, user_rating, and added_to_list_on attributes
Endpoint for media results can now pass optional query params of `user_id=<valid user id>` so that user list information shows up for relevant search results.  

# List any known issues (include relevant code snippets): 
- none


# Necessary checkmarks (replace space between brackets with 'x' to check box): 
  - [x] All tests are passing 
  - [x] Code will run locally 
  - [x] Confirm self-review 
  
# Json response snippet: 
### User Dashboard Lists Endpoint
`http://localhost:5000/api/v1/users/1/lists?list=want to watch`
```
{
    "data": [
        {
            "id": "1402919",
            "type": "media",
            "attributes": {
                "id": 1402919,
                "title": "The Lego Batman Movie",
                "audience_score": 7.6,
                "rating": null,
                "media_type": "movie",
                "description": "A cooler-than-ever Bruce Wayne must deal with the usual suspects as they plan to rule Gotham City, while discovering that he has accidentally adopted a teenage orphan who wishes to become his sidekick.",
                "genres": [
                    "Action",
                    "Animation",
                    "Comedy",
                    "Family"
                ],
                "release_year": 2017,
                "runtime": 104,
                "language": "en",
                "sub_services": [
                    "HBO MAX"
                ],
                "poster": "https://cdn.watchmode.com/posters/01402919_poster_w185.jpg",
                "imdb_id": "tt4116284",
                "tmdb_id": 324849,
                "tmdb_type": "movie",
                "trailer": "https://www.youtube.com/watch?v=rGQUKzSDhrg",
                "user_lists": "Want to Watch",
                "added_to_list_on": "2023-03-02T20:34:20.287Z",
                "user_rating": 3
            }
        }
    ]
}
```

### Media Results (User logged in)
`http://localhost:5000/api/v1/media?user_id=1&q=lego`

```
{
    "data": [
        {
            "id": "1402919",
            "type": "search_result",
            "attributes": {
                "id": 1402919,
                "title": "The Lego Batman Movie",
                "media_type": "movie",
                "release_year": 2017,
                "tmdb_id": 324849,
                "tmdb_type": "movie",
                "poster": "https://cdn.watchmode.com/posters/01402919_poster_w185.jpg",
                "user_lists": "Want to Watch",
                "added_to_list_on": "2023-03-02T20:34:20.287Z",
                "user_rating": 3
            }
        },
        {
            "id": "1402920",
            "type": "search_result",
            "attributes": {
                "id": 1402920,
                "title": "The Lego Movie",
                "media_type": "movie",
                "release_year": 2014,
                "tmdb_id": 137106,
                "tmdb_type": "movie",
                "poster": "https://cdn.watchmode.com/posters/01402920_poster_w185.jpg",
                "user_lists": "None",
                "added_to_list_on": null,
                "user_rating": null
            }
        },
        {
            "id": "1402921",
            "type": "search_result",
            "attributes": {
                "id": 1402921,
                "title": "The Lego Movie 2: The Second Part",
                "media_type": "movie",
                "release_year": 2019,
                "tmdb_id": 280217,
                "tmdb_type": "movie",
                "poster": "https://cdn.watchmode.com/posters/01402921_poster_w185.jpg",
                "user_lists": "None",
                "added_to_list_on": null,
                "user_rating": null
            }
        },
        .
        .
        .
        }
    ]
}
```



